### PR TITLE
[custom-header][main-menu] Categorías padre accesibles.

### DIFF
--- a/assets/css/custom-header.css
+++ b/assets/css/custom-header.css
@@ -446,6 +446,27 @@ header .custom-logo-link img {
   color: #374151;
 }
 
+.submenu-view-all {
+  margin: 0 0 1rem 0;
+}
+
+.submenu-view-all a {
+  display: block;
+  padding: 0.45rem 0.65rem;
+  background: #f0f7ff;
+  color: var(--ocellaris-blue);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s;
+}
+
+.submenu-view-all a:hover {
+  background: #e3f0ff;
+  color: #1d4f9c;
+}
+
 .submenu-panel-content ul {
   list-style: none;
   margin: 0;

--- a/assets/js/custom-header.js
+++ b/assets/js/custom-header.js
@@ -19,6 +19,21 @@
         const searchClear = searchForm.find('.search-clear');
         const searchSubmit = searchForm.find('.search-submit');
 
+        function escapeHtml(value) {
+            return $('<div>').text(value == null ? '' : String(value)).html();
+        }
+
+        function buildViewAllLink(title, href) {
+            if (!href) {
+                return '';
+            }
+
+            const safeTitle = escapeHtml((title || '').trim());
+            const safeHref = escapeHtml(href);
+
+            return '<div class="submenu-view-all"><a href="' + safeHref + '">Ver todo de ' + safeTitle + '</a></div>';
+        }
+
         function isMobileSearch() {
             return window.matchMedia('(max-width: 768px)').matches;
         }
@@ -215,6 +230,7 @@
 
                 // Construir panel con hijos
                 let html = '<h4>' + title + '</h4>';
+                html += buildViewAllLink(title, href);
                 $children.each(function() {
                     const $child = $(this);
                     const $a = $child.children('a');
@@ -274,6 +290,7 @@
 
                 // Construir y abrir el panel
                 let out = '<h4>' + (data.title || title) + '</h4>';
+                out += buildViewAllLink(data.title || title, href);
                 groups.forEach(function(group) {
                     const hasGroupTitle = group.title && group.title.length;
                     out += '<div class="submenu-group">';


### PR DESCRIPTION
Este pull request mejora los paneles de submenú en la cabecera del sitio agregando un enlace "Ver Todo" para cada submenú, lo que mejora la navegación y la experiencia del usuario. La actualización incluye tanto lógica de JavaScript para generar el enlace como estilos CSS correspondientes para una aplicación consistente.

<img width="1584" height="768" alt="image" src="https://github.com/user-attachments/assets/ae91babc-9099-4016-a47f-5a1d9a4770e5" />


**Implementación del enlace "Ver Todo" en Submenú:**
* Se agregó la función `buildViewAllLink` en `custom-header.js` para generar un enlace seguro, localizado y traducido "Ver Todo" para cada panel de submenú, incluyendo HTML escapado para garantizar la seguridad.
* Se integró el enlace "Ver Todo" en el proceso de renderizado de paneles de submenú, asegurándose de que aparezca debajo del título del submenú en tanto en los paneles de submenú hijos como en los grupos de paneles de submenú. [[1]](diffhunk://#diff-754bd2fec763dd730ad19537c0e59938b993c3fc6ee74683af3825f950f50429R233) [[2]](diffhunk://#diff-754bd2fec763dd730ad19537c0e59938b993c3fc6ee74683af3825f950f50429R293)
**Actualizaciones de Estilo:**
* Se introdujeron reglas CSS `.submenu-view-all` en `custom-header.css` para diseño, fondo, color y efectos de hover que coincidan con el sistema de diseño del sitio web.